### PR TITLE
feat: handle $meta.cache

### DIFF
--- a/errors.json
+++ b/errors.json
@@ -1,3 +1,6 @@
 {
-
+    "portCache": "Cache error",
+    "portCache.missingId": "Method {methodName} cache called without $meta.cache.key.id",
+    "portCache.missingCache": "Method {methodName} cache called without $meta.cache",
+    "portCache.invalidOperation": "Method {methodName} cache called with invalid $meta.cache.operation=${operation}"
 }

--- a/index.js
+++ b/index.js
@@ -56,12 +56,12 @@ module.exports = ({utPort, registerErrors, utBus}) => class CachePort extends ut
     get({id, segment}) {
         return this.client.get({id, segment});
     }
-    set({id, segment, value, ttl = this.config.ttl}) {
-        this.client.set({id, segment}, value, ttl);
+    async set({id, segment, value, ttl = this.config.ttl}) {
+        await this.client.set({id, segment}, value, ttl);
         return null;
     }
-    drop({id, segment}) {
-        this.client.drop({id, segment});
+    async drop({id, segment}) {
+        await this.client.drop({id, segment});
         return null;
     }
     handlers() {

--- a/index.js
+++ b/index.js
@@ -1,12 +1,13 @@
 'use strict';
 const Catbox = require('catbox');
 const errors = require('./errors.json');
+const url = require('url');
+
 module.exports = ({utPort, registerErrors, utBus}) => class CachePort extends utPort {
     get defaults() {
         return {
             type: 'cache',
             client: {// catbox extension
-                engine: require('catbox-memory'), // catbox default engine
                 options: {} // catbox engine options
             },
             namespace: ['cache'],
@@ -16,35 +17,64 @@ module.exports = ({utPort, registerErrors, utBus}) => class CachePort extends ut
     init(...params) {
         Object.assign(this.errors, registerErrors(errors));
         const {engine, options} = this.config.client;
-        this.client = new Catbox.Client(engine, options);
+        this.client = new Catbox.Client(engine || require('catbox-memory'), options);
         return super.init(...params);
     }
     async start(...params) {
         await this.client.start();
-        this.pull((msg = {}, $meta = {}) => {
-            const method = $meta.method;
-            if (!method) throw utBus.errors['bus.missingMethod']();
-            const handler = this.methods[method];
-            if (typeof handler !== 'function') throw utBus.errors['bus.methodNotFound']({params: {method}});
-            return handler(msg, $meta).catch(e => {
-                throw this.errors.cache(e);
-            });
-        });
+        this.pull(this.exec);
         return super.start(...params);
     }
-    handlers() {
-        const handlers = {
-            'cache.get': ({id, segment}) => this.client.get({id, segment}),
-            'cache.set': ({id, segment, value, ttl = 0}) => this.client.set({id, segment}, value, ttl),
-            'cache.drop': ({id, segment}) => this.client.drop({id, segment})
+    async exec(...params) {
+        let $meta = params && params.length > 1 && params[params.length - 1];
+        let methodName = $meta && $meta.method;
+        if (!methodName) throw utBus.errors['bus.missingMethod']();
+        let cache = $meta && $meta.cache;
+        if (!cache) throw this.errors['cachePort.missingCache']({methodName});
+        if (!['get', 'set', 'drop'].includes(cache.operation)) throw this.errors['cachePort.missingOperation']({methodName, operation: cache.operation});
+        let segment = cache.key && cache.key.segment;
+        if (!segment) {
+            let cacheParams = cache.key && cache.key.params;
+            if (cacheParams && typeof cacheParams === 'object') {
+                cacheParams = new url.URLSearchParams(cacheParams);
+                cacheParams.sort();
+            }
+            segment = cacheParams ? methodName + '?' + cacheParams.toString() : methodName;
+        }
+        let id = cache.key && cache.key.id;
+        if (id == null) {
+            throw this.errors['cachePort.missingId']({methodName});
+        }
+        try {
+            let fn = this.methods[segment] || this;
+            let cached = await fn[cache.operation].call(this, {id, segment, value: params[0], ttl: cache.ttl});
+            return cached && cached.item;
+        } catch (e) {
+            throw this.errors.cachePort(e);
         };
+    }
+    get({id, segment}) {
+        return this.client.get({id, segment});
+    }
+    set({id, segment, value, ttl = this.config.ttl}) {
+        this.client.set({id, segment}, value, ttl);
+        return null;
+    }
+    drop({id, segment}) {
+        this.client.drop({id, segment});
+        return null;
+    }
+    handlers() {
+        const handlers = {};
         if (Array.isArray(this.config.policy)) {
             this.config.policy.forEach(policyConfig => {
                 const {options = {}, segment} = policyConfig;
                 const policy = new Catbox.Policy(options, this.client, segment);
-                handlers[`cache.${segment}.get`] = ({id}) => policy.get(id);
-                handlers[`cache.${segment}.set`] = ({id, value, ttl = 0}) => policy.set(id, value, ttl);
-                handlers[`cache.${segment}.drop`] = ({id}) => policy.drop(id);
+                handlers[segment] = {
+                    get: ({id}) => policy.get(id),
+                    set: ({id, value, ttl = this.config.ttl}) => policy.set(id, value, ttl),
+                    drop: ({id}) => policy.drop(id)
+                };
             });
         }
         return handlers;


### PR DESCRIPTION
Refactor, so that cache port can be called with original method names and use the $meta to determine cache operation. This is similar to using bus.importMethod('cache/some.method.name')(value,cacheOptions), though most of the time we will probably pass `cache` configuration to importMethod - see here: https://github.com/softwaregroup-bg/ut-bus/pull/58

Maybe we can simplify the policy config, where we can specify policy per each cached segment, for example this looks easier:
```js
policy: {
    'some.method': {expiresIn: 1000},
    'some.method?param': {expiresIn: 2000},
    'some.method?param=value': {expiresIn: 3000}
}
```
We can also think of allowing customized handling of cache operations for each segment, by implementing this in the handlers.